### PR TITLE
feat: show Docs and GitHub inline in mobile nav bar

### DIFF
--- a/landing-page-app/components/Nav.tsx
+++ b/landing-page-app/components/Nav.tsx
@@ -164,6 +164,51 @@ export default function Nav() {
           </a>
         </div>
 
+        {/* Mobile inline links (Docs + GitHub) */}
+        <div
+          className="show-mobile"
+          style={{
+            display: "none",
+            alignItems: "center",
+            gap: "0.25rem",
+          }}
+        >
+          <a
+            href="https://docs.draftai.us"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => ph?.capture(EVENTS.DOCS_CLICKED, { source: "nav_mobile_inline" })}
+            style={{
+              fontFamily: "var(--font-body)",
+              fontSize: "0.875rem",
+              color: "var(--color-muted)",
+              textDecoration: "none",
+              letterSpacing: "0.01em",
+              padding: "12px 16px",
+            }}
+          >
+            Docs
+          </a>
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => ph?.capture(EVENTS.GITHUB_CLICKED, { source: "nav_mobile_inline" })}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              color: "var(--color-muted)",
+              opacity: 0.7,
+              padding: "12px 16px",
+            }}
+            aria-label="View on GitHub"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
+            </svg>
+          </a>
+        </div>
+
         {/* Mobile menu button */}
         <button
           onClick={() => {
@@ -179,7 +224,7 @@ export default function Nav() {
             padding: "8px",
             color: "var(--color-primary)",
           }}
-          className="show-mobile"
+          className="show-mobile mobile-hamburger"
           aria-label="Toggle menu"
         >
           <div
@@ -229,42 +274,19 @@ export default function Nav() {
           {[
             { label: "Features", href: "#features" },
             { label: "How it works", href: "#how-it-works" },
-            { label: "Docs", href: "https://docs.draftai.us", external: true },
-          ].map(({ label, href, ...rest }) => (
+          ].map(({ label, href }) => (
             <a
               key={label}
               href={href}
               onClick={() => {
                 setMenuOpen(false);
-                label === "Docs"
-                  ? ph?.capture(EVENTS.DOCS_CLICKED, { source: "nav_mobile" })
-                  : ph?.capture(EVENTS.NAV_LINK_CLICKED, { source: "nav_mobile", label });
+                ph?.capture(EVENTS.NAV_LINK_CLICKED, { source: "nav_mobile", label });
               }}
-              {...("external" in rest && rest.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
               style={{ color: "var(--color-muted)", textDecoration: "none", fontSize: "1rem" }}
             >
               {label}
             </a>
           ))}
-          <a
-            href={GITHUB_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => ph?.capture(EVENTS.GITHUB_CLICKED, { source: "nav_mobile" })}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "0.5rem",
-              color: "var(--color-muted)",
-              textDecoration: "none",
-              fontSize: "0.9rem",
-            }}
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
-            </svg>
-            View on GitHub
-          </a>
           <a
             href={DOWNLOAD_URL}
             onClick={() => ph?.capture(EVENTS.DOWNLOAD_CLICKED, { source: "nav_mobile" })}
@@ -287,7 +309,8 @@ export default function Nav() {
       <style>{`
         @media (max-width: 768px) {
           .hidden-mobile { display: none !important; }
-          .show-mobile { display: flex !important; flex-direction: column; }
+          .show-mobile { display: flex !important; }
+          .mobile-hamburger { flex-direction: column; }
         }
         @media (min-width: 769px) {
           .show-mobile { display: none !important; }


### PR DESCRIPTION
Moves Docs and GitHub icon out of the hamburger menu and into the always-visible mobile nav bar. Hamburger menu now only contains Features, How it works, and Download.