### PR TITLE
feat: add auto-update system with menu item and Settings section

### DIFF
--- a/desktop/electrobun.config.ts
+++ b/desktop/electrobun.config.ts
@@ -17,6 +17,9 @@ export default {
     identifier: "us.draftai.draft-desktop",
     version: "0.2.1",
   },
+  release: {
+    baseUrl: "https://github.com/idodekerobo/draft/releases/latest/download",
+  },
   runtime: {
     exitOnLastWindowClosed: false,
   },

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -44,6 +44,10 @@ export function App() {
   // Blue dot on Context sidebar item — set by ContextViewer when loadDiff finds new entries.
   // Cleared when the user navigates to the Context tab.
   const [contextHasNew, setContextHasNew] = useState(false);
+  const [updateReady, setUpdateReady]       = useState(false);
+  const [updateVersion, setUpdateVersion]   = useState<string | null>(null);
+  const [isApplyingUpdate, setIsApplyingUpdate] = useState(false);
+  const [updateToast, setUpdateToast] = useState<{ type: "success" | "error"; msg: string } | null>(null);
 
   useEffect(() => {
     if (status?.appState?.userState === "no-profile") setOnboardingActive(true);
@@ -133,6 +137,40 @@ export function App() {
     const id = setTimeout(() => setStartError(null), 4_000);
     return () => clearTimeout(id);
   }, [startError]);
+
+  // ── Update events ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    const unsubs = [
+      events.on("updateAvailable", ({ version }) => {
+        setUpdateVersion(version);
+        setUpdateReady(true);
+      }),
+      events.on("updateNotAvailable", () => {
+        setUpdateToast({ type: "success", msg: "Draft is up to date" });
+      }),
+      events.on("updateCheckFailed", ({ error }) => {
+        setUpdateToast({ type: "error", msg: error });
+      }),
+    ];
+    return () => unsubs.forEach((u) => u());
+  }, []);
+
+  useEffect(() => {
+    if (!updateToast) return;
+    const id = setTimeout(() => setUpdateToast(null), 3_500);
+    return () => clearTimeout(id);
+  }, [updateToast]);
+
+  async function handleApplyUpdate() {
+    setIsApplyingUpdate(true);
+    try {
+      await rpc.request.applyUpdate();
+      // App restarts — this line is usually not reached.
+    } catch {
+      setUpdateToast({ type: "error", msg: "Failed to apply update. Try again." });
+      setIsApplyingUpdate(false);
+    }
+  }
 
 
 
@@ -285,6 +323,24 @@ export function App() {
           )}
         </main>
       </div>
+      {updateReady && updateVersion && (
+        <div className="update-banner" role="status">
+          <span>Draft {updateVersion} is ready to install</span>
+          <button
+            className="update-banner__btn"
+            onClick={() => void handleApplyUpdate()}
+            disabled={isApplyingUpdate}
+          >
+            {isApplyingUpdate ? "Restarting…" : "Restart & Update"}
+          </button>
+        </div>
+      )}
+      {updateToast && (
+        <div className={`toast toast--${updateToast.type}`} role={updateToast.type === "error" ? "alert" : "status"}>
+          <span>{updateToast.msg}</span>
+          <button className="toast__dismiss" onClick={() => setUpdateToast(null)} aria-label="Dismiss">✕</button>
+        </div>
+      )}
       {startError && (
         <div className="toast toast--error" role="alert">
           <span>{startError}</span>

--- a/desktop/src/app/components/views/SettingsView.tsx
+++ b/desktop/src/app/components/views/SettingsView.tsx
@@ -7,13 +7,14 @@
 //   Input Sources       — which integrations are connected; disconnect action
 //   System              — Start on login, Enable notifications
 //   Privacy             — interaction recording opt-out
+//   Updates             — current version, check for updates
 //
 // Connected apps data (getConnectedApps) and settings (getLocalConfig) are
 // loaded in parallel on mount and on every profile switch.
 
 import { useEffect, useState } from "react";
-import type { ConnectedAppsStatus, ContextSection, InstallableTool, IntegrationDetail, LocalConfig, ToolDetail } from "../../../rpc/schema";
-import { rpc } from "../../rpc";
+import type { AppVersionInfo, ConnectedAppsStatus, ContextSection, InstallableTool, IntegrationDetail, LocalConfig, ToolDetail } from "../../../rpc/schema";
+import { events, rpc } from "../../rpc";
 import { useAnalytics } from "../../analytics/AnalyticsContext";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -263,6 +264,9 @@ export function SettingsView({ activeProfile }: SettingsViewProps) {
   const [saveError, setSaveError]         = useState<string | null>(null);
   const [disconnecting, setDisconnecting] = useState<"granola" | "slack" | "github" | null>(null);
   const [connectingGitHub, setConnectingGitHub] = useState(false);
+  const [versionInfo, setVersionInfo]     = useState<AppVersionInfo | null>(null);
+  const [updateCheckState, setUpdateCheckState] = useState<"idle" | "checking" | "available" | "up-to-date" | "failed">("idle");
+  const [pendingVersion, setPendingVersion] = useState<string | null>(null);
 
   const { config: analyticsConfig, setReplayEnabled, track } = useAnalytics();
 
@@ -276,14 +280,36 @@ export function SettingsView({ activeProfile }: SettingsViewProps) {
       rpc.request.getLocalConfig(),
       rpc.request.getConnectedApps(),
       rpc.request.getContextSections(),
+      rpc.request.getAppVersion(),
     ])
-      .then(([config, connectedApps, contextSections]) => {
+      .then(([config, connectedApps, contextSections, appVersion]) => {
         setSettings(config);
         setApps(connectedApps);
         setSections(contextSections);
+        setVersionInfo(appVersion);
       })
       .catch(() => setLoadError("Failed to load settings."));
   }, [activeProfile]);
+
+  // ── Update events ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    const unsubs = [
+      events.on("updateCheckStarted", () => setUpdateCheckState("checking")),
+      events.on("updateAvailable", ({ version }) => {
+        setPendingVersion(version);
+        setUpdateCheckState("available");
+      }),
+      events.on("updateNotAvailable", () => {
+        setUpdateCheckState("up-to-date");
+        setTimeout(() => setUpdateCheckState("idle"), 3_000);
+      }),
+      events.on("updateCheckFailed", () => {
+        setUpdateCheckState("failed");
+        setTimeout(() => setUpdateCheckState("idle"), 5_000);
+      }),
+    ];
+    return () => unsubs.forEach((u) => u());
+  }, []);
 
   // ── Save error auto-dismiss ────────────────────────────────────────────────
   useEffect(() => {
@@ -387,6 +413,12 @@ export function SettingsView({ activeProfile }: SettingsViewProps) {
     return () => { clearInterval(id); clearTimeout(timeout); };
   }, [connectingGitHub]);
 
+  // ── Check for updates ──────────────────────────────────────────────────────
+  function handleCheckForUpdates() {
+    setUpdateCheckState("checking");
+    rpc.send.requestUpdateCheck({});
+  }
+
   // ── Loading / error states ─────────────────────────────────────────────────
   if (loadError) {
     return (
@@ -405,6 +437,14 @@ export function SettingsView({ activeProfile }: SettingsViewProps) {
       </div>
     );
   }
+
+  // ── Derived update desc ────────────────────────────────────────────────────
+  const updateDesc =
+    updateCheckState === "checking"   ? "Checking for updates…"                          :
+    updateCheckState === "available"  ? `Version ${pendingVersion ?? ""} is ready to install` :
+    updateCheckState === "up-to-date" ? "You're up to date"                               :
+    updateCheckState === "failed"     ? "Could not check for updates"                     :
+    versionInfo && versionInfo.channel !== "dev" ? `${versionInfo.channel} channel`       : "";
 
   // ── Render ─────────────────────────────────────────────────────────────────
   return (
@@ -546,6 +586,37 @@ export function SettingsView({ activeProfile }: SettingsViewProps) {
             </div>
           </section>
         )}
+
+        {/* ── Updates ─────────────────────────────────────────────────────── */}
+        <section className="settings__section">
+          <h2 className="settings__section-label">Updates</h2>
+          <div className="settings__rows">
+            <div className="settings__row">
+              <div className="settings__row-content">
+                <span className="settings__row-label">
+                  {versionInfo ? `Draft ${versionInfo.version}` : "Draft"}
+                </span>
+                <span className="settings__row-desc">{updateDesc}</span>
+              </div>
+              {updateCheckState === "available" ? (
+                <button
+                  className="app-row__connect"
+                  onClick={() => void rpc.request.applyUpdate()}
+                >
+                  Restart & Update
+                </button>
+              ) : (
+                <button
+                  className="app-row__connect"
+                  onClick={handleCheckForUpdates}
+                  disabled={updateCheckState === "checking"}
+                >
+                  {updateCheckState === "checking" ? "Checking…" : "Check for Updates"}
+                </button>
+              )}
+            </div>
+          </div>
+        </section>
 
       </div>
 

--- a/desktop/src/app/index.css
+++ b/desktop/src/app/index.css
@@ -678,6 +678,11 @@ button {
   color: #fff;
 }
 
+.toast--success {
+  background: var(--color-status-green);
+  color: #fff;
+}
+
 .toast__dismiss {
   background: transparent;
   border: none;
@@ -696,6 +701,51 @@ button {
 @keyframes toast-in {
   from { opacity: 0; transform: translateX(-50%) translateY(6px); }
   to   { opacity: 1; transform: translateX(-50%) translateY(0);   }
+}
+
+/* ── Update banner ────────────────────────────────────────────────────────────── */
+/* Persistent bar anchored to the bottom of the window when an update is staged.  */
+
+.update-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: var(--color-accent-blue);
+  color: #fff;
+  font-size: var(--font-size-secondary);
+  z-index: 1500;
+  animation: update-banner-in 200ms ease;
+}
+
+.update-banner__btn {
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: var(--radius-sm);
+  color: #fff;
+  font-size: var(--font-size-secondary);
+  padding: 4px 12px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 120ms ease;
+}
+
+.update-banner__btn:hover {
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.update-banner__btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+@keyframes update-banner-in {
+  from { opacity: 0; transform: translateY(100%); }
+  to   { opacity: 1; transform: translateY(0);    }
 }
 
 /* ── Context viewer ──────────────────────────────────────────────────────────── */

--- a/desktop/src/app/rpc.ts
+++ b/desktop/src/app/rpc.ts
@@ -20,6 +20,10 @@ type EventMap = {
   badgeUpdate: { profile: string; count: number };
   profileChanged: { profile: string };
   requestStatusRefresh: Record<string, never>;
+  updateCheckStarted: Record<string, never>;
+  updateAvailable: { version: string };
+  updateNotAvailable: Record<string, never>;
+  updateCheckFailed: { error: string };
 };
 
 // Internal listener type — erased at call sites; external API remains typed.
@@ -66,9 +70,12 @@ export const rpc = Electroview.defineRPC<AppRPCType>({
       // TODO: Phase 2: update badge count in nav
       badgeUpdate: (data) => events.emit("badgeUpdate", data),
 
-      // TODO: Phase 1: active profile changed via desktop or CLI
       profileChanged: (data) => events.emit("profileChanged", data),
       requestStatusRefresh: (data) => events.emit("requestStatusRefresh", data),
+      updateCheckStarted: (data) => events.emit("updateCheckStarted", data),
+      updateAvailable: (data) => events.emit("updateAvailable", data),
+      updateNotAvailable: (data) => events.emit("updateNotAvailable", data),
+      updateCheckFailed: (data) => events.emit("updateCheckFailed", data),
     },
   },
 });

--- a/desktop/src/index.ts
+++ b/desktop/src/index.ts
@@ -42,6 +42,8 @@ function setAppMenu(daemonRunning: boolean) {
   ApplicationMenu.setApplicationMenu([
     {
       submenu: [
+        { label: "Check for Updates", action: "check-for-updates" },
+        { type: "separator" },
         daemonRunning
           ? { label: "Stop Draft",  action: "stop-draft"  }
           : { label: "Start Draft", action: "start-draft" },
@@ -69,6 +71,11 @@ setAppMenu(true);
 
 Electrobun.events.on("application-menu-clicked", (event) => {
   const { action } = (event as { data: { action: string } }).data;
+
+  if (action === "check-for-updates") {
+    try { rpc.send.updateCheckStarted({}); } catch {}
+    void checkAndDownloadUpdate(false);
+  }
 
   if (action === "stop-draft") {
     capture(["launchctl", "unload", PLIST_PATH])
@@ -703,6 +710,27 @@ const rpc = BrowserView.defineRPC<AppRPCType>({
         return result;
       },
 
+      applyUpdate: async () => {
+        try {
+          if (!Electrobun.Updater.updateInfo()?.updateReady) {
+            return { ok: false, error: "No update is staged." };
+          }
+          await Electrobun.Updater.applyUpdate();
+          return { ok: true }; // unreachable — app restarts
+        } catch (err) {
+          return { ok: false, error: err instanceof Error ? err.message : "Apply failed." };
+        }
+      },
+
+      getAppVersion: async () => {
+        try {
+          const info = await Electrobun.Updater.getLocalInfo();
+          return { version: info.version, channel: info.channel };
+        } catch {
+          return { version: "dev", channel: "dev" };
+        }
+      },
+
       getAnalyticsConfig: async () => {
         const result = readDraftConfig();
         const config: import("draft-core/config").DraftConfig = result.ok ? result.config : { version: "1", tools: {} };
@@ -739,9 +767,34 @@ const rpc = BrowserView.defineRPC<AppRPCType>({
       openUrl: ({ url }) => {
         Bun.spawn(["open", url], { stdin: "ignore", stdout: "ignore", stderr: "ignore" });
       },
+      requestUpdateCheck: () => {
+        void checkAndDownloadUpdate(false);
+      },
     },
   },
 });
+
+// ── Update helpers ─────────────────────────────────────────────────────────────
+
+async function checkAndDownloadUpdate(silent: boolean) {
+  try {
+    const info = await Electrobun.Updater.checkForUpdate();
+    if (!info.updateAvailable) {
+      if (!silent) try { rpc.send.updateNotAvailable({}); } catch {}
+      return;
+    }
+    await Electrobun.Updater.downloadUpdate();
+    const ready = Electrobun.Updater.updateInfo()?.updateReady ?? false;
+    if (ready) {
+      try { rpc.send.updateAvailable({ version: info.version }); } catch {}
+    }
+  } catch (err) {
+    if (!silent) {
+      const error = err instanceof Error ? err.message : "Update check failed.";
+      try { rpc.send.updateCheckFailed({ error }); } catch {}
+    }
+  }
+}
 
 // Assign after rpc is constructed so rpc.send is available in the closures,
 // but before any handler or watcher fires.
@@ -849,4 +902,7 @@ setTimeout(async () => {
       try { rpc.send.profileChanged({ profile }); } catch {}
     },
   });
+
+  // Silent update check on launch — pushes updateAvailable if a new version is ready.
+  void checkAndDownloadUpdate(true);
 }, 500);

--- a/desktop/src/rpc/schema.ts
+++ b/desktop/src/rpc/schema.ts
@@ -153,6 +153,18 @@ export interface LocalConfig {
   disabledContextSections: string[];
 }
 
+export interface UpdateInfo {
+  version: string;
+  updateAvailable: boolean;
+  updateReady: boolean;
+  error?: string;
+}
+
+export interface AppVersionInfo {
+  version: string;
+  channel: string;
+}
+
 export interface AnalyticsConfig {
   consent: "pending" | "opted_in" | "opted_out";
   replay_enabled: boolean;
@@ -324,12 +336,20 @@ export type AppRPCType = {
 
       /** Patch analytics config (consent, replay_enabled, etc.) in ~/.draft/config.json. */
       setAnalyticsConfig: { params: Partial<AnalyticsConfig>; response: ActionResult };
+
+      /** Apply a staged update — quits + relaunches. Only valid when updateReady is true. */
+      applyUpdate: { params: void; response: ActionResult };
+
+      /** Read version + channel from bundled version.json. Returns { version: "dev", channel: "dev" } in dev builds. */
+      getAppVersion: { params: void; response: AppVersionInfo };
     };
     messages: {
       /** Renderer asks bun to fire a macOS notification. */
       sendNotification: { title: string; subtitle?: string; body?: string };
       /** Renderer asks Bun to open a URL in the system browser. */
       openUrl: { url: string };
+      /** Renderer asks bun to start an update check. Result arrives via webview messages. */
+      requestUpdateCheck: Record<string, never>;
     };
   }>;
 
@@ -361,6 +381,18 @@ export type AppRPCType = {
 
       /** Bun asks renderer to re-fetch status immediately (e.g. after a menu start/stop action). */
       requestStatusRefresh: Record<string, never>;
+
+      /** Bun started an update check. */
+      updateCheckStarted: Record<string, never>;
+
+      /** Update downloaded and staged — ready to apply. */
+      updateAvailable: { version: string };
+
+      /** Update check completed — already on latest version. */
+      updateNotAvailable: Record<string, never>;
+
+      /** Update check or download failed. */
+      updateCheckFailed: { error: string };
     };
   }>;
 };


### PR DESCRIPTION
- Add "Check for Updates" to Draft app menu (macOS menu bar)
- Silent update check on launch; downloads in background when available
- Persistent update banner slides up from bottom when update is staged
- "Up to date" / error toasts for menu-triggered checks
- Settings → Updates section shows current version and Check/Restart button
- Wire Electrobun Updater API (checkForUpdate, downloadUpdate, applyUpdate)
- Add release.baseUrl in electrobun.config.ts for GitHub Releases