### PR TITLE
feat(landing): add Crisp chat widget

### DIFF
--- a/landing-page-app/app/layout.tsx
+++ b/landing-page-app/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Fraunces, Plus_Jakarta_Sans, JetBrains_Mono } from "next/font/google";
 import { PostHogProvider } from "@/lib/PostHogProvider";
+import CrispChat from "@/components/CrispChat";
 import "./globals.css";
 
 const fraunces = Fraunces({
@@ -57,6 +58,7 @@ export default function RootLayout({
         <PostHogProvider>
           {children}
         </PostHogProvider>
+        <CrispChat />
       </body>
     </html>
   );

--- a/landing-page-app/components/CrispChat.tsx
+++ b/landing-page-app/components/CrispChat.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { Crisp } from "crisp-sdk-web";
+
+export default function CrispChat() {
+  useEffect(() => {
+    const websiteId = process.env.NEXT_PUBLIC_CRISP_WEBSITE_ID;
+    if (websiteId) {
+      Crisp.configure(websiteId);
+    }
+  }, []);
+  return null;
+}

--- a/landing-page-app/package-lock.json
+++ b/landing-page-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "landing-page-app",
       "version": "0.1.0",
       "dependencies": {
+        "crisp-sdk-web": "^1.1.2",
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
         "posthog-js": "^1.360.2",
@@ -3117,6 +3118,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/crisp-sdk-web": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/crisp-sdk-web/-/crisp-sdk-web-1.1.2.tgz",
+      "integrity": "sha512-qxSpiT4EGHnVEO6J/t1UURY6fg1ojgquLU0IIr7RNjZxXZs1R2e6AhAiFqxiGZ13Vb4o5VoUpATFU2TzX/ppOQ==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/landing-page-app/package.json
+++ b/landing-page-app/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "crisp-sdk-web": "^1.1.2",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "posthog-js": "^1.360.2",


### PR DESCRIPTION
Installs crisp-sdk-web and adds a CrispChat client component to the root layout. Widget ID is read from NEXT_PUBLIC_CRISP_WEBSITE_ID env var.