### PR TITLE
feat(desktop): add headless crisp chat and feedback call booking via settings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
     "desktop": {
       "name": "draft-desktop",
       "dependencies": {
+        "crisp-sdk-web": "^1.1.2",
         "diff": "^9.0.0",
         "draft-core": "workspace:*",
         "electrobun": "^1.18.1",
@@ -109,6 +110,8 @@
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
+    "crisp-sdk-web": ["crisp-sdk-web@1.1.2", "", {}, "sha512-qxSpiT4EGHnVEO6J/t1UURY6fg1ojgquLU0IIr7RNjZxXZs1R2e6AhAiFqxiGZ13Vb4o5VoUpATFU2TzX/ppOQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 

--- a/desktop/electrobun.config.ts
+++ b/desktop/electrobun.config.ts
@@ -2,16 +2,17 @@ import type { ElectrobunConfig } from "electrobun";
 
 // Read PostHog key + host from build-config.json at config evaluation time.
 // Absent for OSS builds → empty string → phTrack no-ops in the main process.
-let _buildCfg: { posthog_key?: string; api_host?: string; crisp_website_id?: string } = {};
+let _buildCfg: { posthog_key?: string; api_host?: string; crisp_website_id?: string; cal_url?: string } = {};
 try {
   const raw = await Bun.file(new URL("./src/build-config.json", import.meta.url).pathname).text();
-  _buildCfg = JSON.parse(raw) as { posthog_key?: string; api_host?: string; crisp_website_id?: string };
+  _buildCfg = JSON.parse(raw) as { posthog_key?: string; api_host?: string; crisp_website_id?: string; cal_url?: string };
 } catch { /* no build-config.json — OSS build */ }
 
 const isDev      = process.argv.includes("dev");
 const _phKey     = JSON.stringify(isDev ? "" : (_buildCfg.posthog_key ?? ""));
 const _phHost    = JSON.stringify(_buildCfg.api_host         ?? "https://us.i.posthog.com");
 const _crispId   = JSON.stringify(_buildCfg.crisp_website_id ?? "");
+const _calUrl    = JSON.stringify(_buildCfg.cal_url          ?? "");
 
 export default {
   app: {
@@ -30,9 +31,10 @@ export default {
     bun: {
       entrypoint: "src/index.ts",
       define: {
-        "process.env.DRAFT_PH_KEY":          _phKey,
-        "process.env.DRAFT_PH_HOST":         _phHost,
+        "process.env.DRAFT_PH_KEY":           _phKey,
+        "process.env.DRAFT_PH_HOST":          _phHost,
         "process.env.DRAFT_CRISP_WEBSITE_ID": _crispId,
+        "process.env.DRAFT_CAL_URL":          _calUrl,
       },
     },
     views: {

--- a/desktop/electrobun.config.ts
+++ b/desktop/electrobun.config.ts
@@ -2,15 +2,16 @@ import type { ElectrobunConfig } from "electrobun";
 
 // Read PostHog key + host from build-config.json at config evaluation time.
 // Absent for OSS builds → empty string → phTrack no-ops in the main process.
-let _buildCfg: { posthog_key?: string; api_host?: string } = {};
+let _buildCfg: { posthog_key?: string; api_host?: string; crisp_website_id?: string } = {};
 try {
   const raw = await Bun.file(new URL("./src/build-config.json", import.meta.url).pathname).text();
-  _buildCfg = JSON.parse(raw) as { posthog_key?: string; api_host?: string };
+  _buildCfg = JSON.parse(raw) as { posthog_key?: string; api_host?: string; crisp_website_id?: string };
 } catch { /* no build-config.json — OSS build */ }
 
-const isDev   = process.argv.includes("dev");
-const _phKey  = JSON.stringify(isDev ? "" : (_buildCfg.posthog_key ?? ""));
-const _phHost = JSON.stringify(_buildCfg.api_host    ?? "https://us.i.posthog.com");
+const isDev      = process.argv.includes("dev");
+const _phKey     = JSON.stringify(isDev ? "" : (_buildCfg.posthog_key ?? ""));
+const _phHost    = JSON.stringify(_buildCfg.api_host         ?? "https://us.i.posthog.com");
+const _crispId   = JSON.stringify(_buildCfg.crisp_website_id ?? "");
 
 export default {
   app: {
@@ -29,8 +30,9 @@ export default {
     bun: {
       entrypoint: "src/index.ts",
       define: {
-        "process.env.DRAFT_PH_KEY":  _phKey,
-        "process.env.DRAFT_PH_HOST": _phHost,
+        "process.env.DRAFT_PH_KEY":          _phKey,
+        "process.env.DRAFT_PH_HOST":         _phHost,
+        "process.env.DRAFT_CRISP_WEBSITE_ID": _crispId,
       },
     },
     views: {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,6 +11,7 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "crisp-sdk-web": "^1.1.2",
     "diff": "^9.0.0",
     "draft-core": "workspace:*",
     "electrobun": "^1.18.1",

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -21,6 +21,7 @@ import { SettingsView } from "./components/views/SettingsView";
 import { ActivityView } from "./components/views/ActivityView";
 import { OnboardingView } from "./components/views/OnboardingView";
 import { SetupIncompleteView } from "./components/views/SetupIncompleteView";
+import { SupportPanel } from "./components/SupportPanel";
 
 // ── Polling interval ───────────────────────────────────────────────────────────
 const STATUS_POLL_MS = 5_000;
@@ -49,6 +50,7 @@ export function App() {
   const [updateVersion, setUpdateVersion]   = useState<string | null>(null);
   const [isApplyingUpdate, setIsApplyingUpdate] = useState(false);
   const [updateToast, setUpdateToast] = useState<{ type: "success" | "error"; msg: string } | null>(null);
+  const [supportOpen, setSupportOpen] = useState(false);
 
   useEffect(() => {
     if (status?.appState?.userState === "no-profile") setOnboardingActive(true);
@@ -298,7 +300,7 @@ export function App() {
         <main className="content">
           {/* Settings is always reachable regardless of install/daemon state. */}
           {activeView === "settings" ? (
-            <SettingsView key={activeProfile} activeProfile={activeProfile} />
+            <SettingsView key={activeProfile} activeProfile={activeProfile} onOpenFeedback={() => setSupportOpen(true)} />
           ) : (onboardingActive || status?.appState?.userState === "no-profile") ? (
             <OnboardingView onComplete={async () => { setOnboardingActive(false); await fetchStatus(); }} />
           ) : status?.appState?.userState === "no-context" && !bypassSetup ? (
@@ -357,6 +359,7 @@ export function App() {
           <button className="toast__dismiss" onClick={() => setStartError(null)} aria-label="Dismiss">✕</button>
         </div>
       )}
+      <SupportPanel isOpen={supportOpen} onClose={() => setSupportOpen(false)} />
     </div>
   );
 }

--- a/desktop/src/app/components/SupportPanel.tsx
+++ b/desktop/src/app/components/SupportPanel.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from "react";
+import { useCrispChat } from "../support/useCrispChat";
+
+interface SupportPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function SupportPanel({ isOpen, onClose }: SupportPanelProps) {
+  const { messages, sendMessage, isReady } = useCrispChat();
+  const [draft, setDraft]                  = useState("");
+  const messagesEndRef                     = useRef<HTMLDivElement>(null);
+  const inputRef                           = useRef<HTMLTextAreaElement>(null);
+
+  // Scroll to bottom when new messages arrive.
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  // Focus input when panel opens.
+  useEffect(() => {
+    if (isOpen) setTimeout(() => inputRef.current?.focus(), 60);
+  }, [isOpen]);
+
+  function handleSend() {
+    if (!draft.trim()) return;
+    sendMessage(draft);
+    setDraft("");
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="support-panel" role="dialog" aria-label="Contact Support">
+      <div className="support-panel__header">
+        <span className="support-panel__title">Support</span>
+        <button className="support-panel__close" onClick={onClose} aria-label="Close support panel">
+          ✕
+        </button>
+      </div>
+
+      <div className="support-panel__messages">
+        {messages.length === 0 && (
+          <div className="support-panel__empty">
+            <p className="support-panel__empty-title">Hi there 👋</p>
+            <p className="support-panel__empty-body">
+              Send us a message and we'll get back to you as soon as we can.
+            </p>
+          </div>
+        )}
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            className={`support-panel__bubble support-panel__bubble--${msg.from}`}
+          >
+            {msg.text}
+          </div>
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="support-panel__footer">
+        <textarea
+          ref={inputRef}
+          className="support-panel__input"
+          placeholder="Type a message…"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={!isReady}
+          rows={2}
+        />
+        <button
+          className="support-panel__send"
+          onClick={handleSend}
+          disabled={!isReady || !draft.trim()}
+          aria-label="Send message"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/app/components/views/SettingsView.tsx
+++ b/desktop/src/app/components/views/SettingsView.tsx
@@ -285,6 +285,7 @@ export function SettingsView({ activeProfile, onOpenFeedback }: SettingsViewProp
   const [versionInfo, setVersionInfo]     = useState<AppVersionInfo | null>(null);
   const [updateCheckState, setUpdateCheckState] = useState<"idle" | "checking" | "available" | "up-to-date" | "failed">("idle");
   const [pendingVersion, setPendingVersion] = useState<string | null>(null);
+  const [calUrl, setCalUrl]                = useState<string>("");
 
   const { config: analyticsConfig, setReplayEnabled, track } = useAnalytics();
 
@@ -299,12 +300,14 @@ export function SettingsView({ activeProfile, onOpenFeedback }: SettingsViewProp
       rpc.request.getConnectedApps(),
       rpc.request.getContextSections(),
       rpc.request.getAppVersion(),
+      rpc.request.getCrispConfig(),
     ])
-      .then(([config, connectedApps, contextSections, appVersion]) => {
+      .then(([config, connectedApps, contextSections, appVersion, crispConfig]) => {
         setSettings(config);
         setApps(connectedApps);
         setSections(contextSections);
         setVersionInfo(appVersion);
+        setCalUrl(crispConfig.cal_url);
       })
       .catch(() => setLoadError("Failed to load settings."));
   }, [activeProfile]);
@@ -773,9 +776,19 @@ export function SettingsView({ activeProfile, onOpenFeedback }: SettingsViewProp
                 <span className="feedback-row__label">Share Feedback</span>
                 <span className="feedback-row__desc">Questions, bugs, or ideas — we read everything.</span>
               </div>
-              <button className="feedback-row__btn" onClick={onOpenFeedback}>
-                Open Chat
-              </button>
+              <div className="feedback-row__actions">
+                {calUrl && (
+                  <button
+                    className="feedback-row__btn"
+                    onClick={() => rpc.send.openUrl({ url: calUrl })}
+                  >
+                    Book a Call
+                  </button>
+                )}
+                <button className="feedback-row__btn feedback-row__btn--primary" onClick={onOpenFeedback}>
+                  Open Chat
+                </button>
+              </div>
             </div>
           </section>
         )}

--- a/desktop/src/app/components/views/SettingsView.tsx
+++ b/desktop/src/app/components/views/SettingsView.tsx
@@ -264,9 +264,10 @@ function InputSourceRow({
 
 interface SettingsViewProps {
   activeProfile: string;
+  onOpenFeedback?: () => void;
 }
 
-export function SettingsView({ activeProfile }: SettingsViewProps) {
+export function SettingsView({ activeProfile, onOpenFeedback }: SettingsViewProps) {
   const [settings, setSettings]           = useState<LocalConfig | null>(null);
   const [apps, setApps]                   = useState<ConnectedAppsStatus | null>(null);
   const [sections, setSections]           = useState<ContextSection[]>([]);
@@ -763,6 +764,21 @@ export function SettingsView({ activeProfile }: SettingsViewProps) {
             </div>
           </div>
         </section>
+
+        {/* ── Feedback ────────────────────────────────────────────────────── */}
+        {onOpenFeedback && (
+          <section className="settings__section settings__section--feedback">
+            <div className="feedback-row">
+              <div className="feedback-row__text">
+                <span className="feedback-row__label">Share Feedback</span>
+                <span className="feedback-row__desc">Questions, bugs, or ideas — we read everything.</span>
+              </div>
+              <button className="feedback-row__btn" onClick={onOpenFeedback}>
+                Open Chat
+              </button>
+            </div>
+          </section>
+        )}
 
       </div>
 

--- a/desktop/src/app/index.css
+++ b/desktop/src/app/index.css
@@ -3465,8 +3465,14 @@ button {
   line-height: 1.4;
 }
 
-.feedback-row__btn {
+.feedback-row__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   flex-shrink: 0;
+}
+
+.feedback-row__btn {
   height: 30px;
   padding: 0 14px;
   background: transparent;
@@ -3476,7 +3482,7 @@ button {
   font-size: var(--font-size-secondary);
   font-family: var(--font-ui);
   cursor: pointer;
-  transition: background 120ms, border-color 120ms, color 120ms;
+  transition: background 120ms, border-color 120ms, color 120ms, opacity 120ms;
   white-space: nowrap;
 }
 
@@ -3484,6 +3490,20 @@ button {
   background: rgba(255, 255, 255, 0.06);
   border-color: rgba(255, 255, 255, 0.22);
   color: var(--color-text-primary);
+}
+
+.feedback-row__btn--primary {
+  background: var(--color-accent-blue);
+  border-color: transparent;
+  color: #fff;
+  font-weight: 500;
+}
+
+.feedback-row__btn--primary:hover {
+  background: var(--color-accent-blue);
+  border-color: transparent;
+  color: #fff;
+  opacity: 0.85;
 }
 
 /* ── Support panel ────────────────────────────────────────────────────────────── */

--- a/desktop/src/app/index.css
+++ b/desktop/src/app/index.css
@@ -3421,3 +3421,235 @@ button {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ── Feedback section (Settings bottom) ──────────────────────────────────────── */
+
+.settings__section--feedback {
+  margin-top: 8px;
+  padding: 0 20px 4px;
+}
+
+.feedback-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 16px 20px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.02);
+  transition: border-color 160ms, background 160ms;
+}
+
+.feedback-row:hover {
+  border-color: var(--color-border-strong);
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.feedback-row__text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.feedback-row__label {
+  font-size: var(--font-size-body);
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.feedback-row__desc {
+  font-size: var(--font-size-secondary);
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
+.feedback-row__btn {
+  flex-shrink: 0;
+  height: 30px;
+  padding: 0 14px;
+  background: transparent;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-secondary);
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition: background 120ms, border-color 120ms, color 120ms;
+  white-space: nowrap;
+}
+
+.feedback-row__btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.22);
+  color: var(--color-text-primary);
+}
+
+/* ── Support panel ────────────────────────────────────────────────────────────── */
+/* Floating chat panel anchored to bottom-right of the window.                    */
+
+.support-panel {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  width: 320px;
+  height: 420px;
+  background: var(--color-bg-sidebar);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.55);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 2000;
+  animation: support-panel-in 180ms ease;
+}
+
+@keyframes support-panel-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.support-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 40px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.support-panel__title {
+  font-size: var(--font-size-secondary);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.support-panel__close {
+  background: transparent;
+  border: none;
+  color: var(--color-text-tertiary);
+  font-size: 11px;
+  padding: 4px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color 100ms;
+}
+
+.support-panel__close:hover {
+  color: var(--color-text-secondary);
+}
+
+.support-panel__messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.support-panel__empty {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 0;
+}
+
+.support-panel__empty-title {
+  font-size: var(--font-size-body);
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.support-panel__empty-body {
+  font-size: var(--font-size-secondary);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.support-panel__bubble {
+  max-width: 85%;
+  padding: 8px 11px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-secondary);
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.support-panel__bubble--user {
+  align-self: flex-end;
+  background: var(--color-accent-blue);
+  color: #fff;
+  border-bottom-right-radius: 2px;
+}
+
+.support-panel__bubble--operator {
+  align-self: flex-start;
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
+  border-bottom-left-radius: 2px;
+}
+
+.support-panel__footer {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.support-panel__input {
+  flex: 1;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  color: var(--color-text-primary);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-secondary);
+  padding: 7px 10px;
+  resize: none;
+  outline: none;
+  line-height: 1.4;
+  transition: border-color 120ms;
+}
+
+.support-panel__input::placeholder {
+  color: var(--color-text-tertiary);
+}
+
+.support-panel__input:focus {
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.support-panel__input:disabled {
+  opacity: 0.5;
+}
+
+.support-panel__send {
+  height: 32px;
+  padding: 0 12px;
+  background: var(--color-accent-blue);
+  border: none;
+  border-radius: var(--radius-md);
+  color: #fff;
+  font-size: var(--font-size-secondary);
+  font-weight: 500;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: opacity 120ms;
+}
+
+.support-panel__send:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.support-panel__send:disabled {
+  opacity: 0.4;
+  cursor: default;
+}

--- a/desktop/src/app/support/useCrispChat.ts
+++ b/desktop/src/app/support/useCrispChat.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Crisp } from "crisp-sdk-web";
+import { rpc } from "../rpc";
+
+export interface CrispMessage {
+  id: string;
+  from: "user" | "operator";
+  text: string;
+  timestamp: number;
+}
+
+// Module-level flag — Crisp can only be configured once per page load.
+let _configured = false;
+
+export function useCrispChat() {
+  const [messages, setMessages]   = useState<CrispMessage[]>([]);
+  const [isReady, setIsReady]     = useState(false);
+  const listenerBound             = useRef(false);
+
+  useEffect(() => {
+    async function init() {
+      if (_configured) {
+        setIsReady(true);
+        return;
+      }
+
+      const cfg = await rpc.request.getCrispConfig();
+      if (!cfg.website_id) return; // OSS build — no Crisp key
+
+      Crisp.configure(cfg.website_id, { autoload: false });
+      Crisp.load();
+      Crisp.chat.hide();
+
+      _configured = true;
+      setIsReady(true);
+    }
+
+    void init();
+  }, []);
+
+  useEffect(() => {
+    if (!isReady || listenerBound.current) return;
+    listenerBound.current = true;
+
+    Crisp.message.onMessageReceived((msg: unknown) => {
+      const m = msg as Record<string, unknown>;
+      const text = typeof m?.content === "string" ? m.content : "";
+      if (!text) return;
+
+      setMessages((prev) => [
+        ...prev,
+        {
+          id:        String(m?.fingerprint ?? Date.now()),
+          from:      "operator",
+          text,
+          timestamp: typeof m?.timestamp === "number" ? m.timestamp : Date.now(),
+        },
+      ]);
+    });
+  }, [isReady]);
+
+  const sendMessage = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (!isReady || !trimmed) return;
+
+    setMessages((prev) => [
+      ...prev,
+      { id: String(Date.now()), from: "user", text: trimmed, timestamp: Date.now() },
+    ]);
+
+    Crisp.message.send("text", trimmed);
+  }, [isReady]);
+
+  return { messages, sendMessage, isReady };
+}

--- a/desktop/src/build-config.example.json
+++ b/desktop/src/build-config.example.json
@@ -1,4 +1,5 @@
 {
   "posthog_key": "",
-  "api_host": "https://us.i.posthog.com"
+  "api_host": "https://us.i.posthog.com",
+  "crisp_website_id": ""
 }

--- a/desktop/src/build-config.example.json
+++ b/desktop/src/build-config.example.json
@@ -1,5 +1,6 @@
 {
   "posthog_key": "",
   "api_host": "https://us.i.posthog.com",
-  "crisp_website_id": ""
+  "crisp_website_id": "",
+  "cal_url": ""
 }

--- a/desktop/src/index.ts
+++ b/desktop/src/index.ts
@@ -64,6 +64,7 @@ import type { AppRPCType } from "./rpc/schema";
 const _phKey          = process.env.DRAFT_PH_KEY           ?? "";
 const _phHost         = process.env.DRAFT_PH_HOST          ?? "https://us.i.posthog.com";
 const _crispWebsiteId = process.env.DRAFT_CRISP_WEBSITE_ID ?? "";
+const _calUrl         = process.env.DRAFT_CAL_URL          ?? "";
 
 // ── Application menu ───────────────────────────────────────────────────────────
 
@@ -1012,7 +1013,7 @@ const rpc = BrowserView.defineRPC<AppRPCType>({
       },
 
       getCrispConfig: async () => {
-        return { website_id: _crispWebsiteId };
+        return { website_id: _crispWebsiteId, cal_url: _calUrl };
       },
 
       getAnalyticsConfig: async () => {

--- a/desktop/src/index.ts
+++ b/desktop/src/index.ts
@@ -59,10 +59,11 @@ import {
 } from "draft-core/sync/manifest";
 import type { AppRPCType } from "./rpc/schema";
 
-// Key + host baked in at build time via electrobun.config.ts define → process.env.
-// Falls back to empty string for OSS builds (no build-config.json) → phTrack no-ops.
-const _phKey  = process.env.DRAFT_PH_KEY  ?? "";
-const _phHost = process.env.DRAFT_PH_HOST ?? "https://us.i.posthog.com";
+// Keys baked in at build time via electrobun.config.ts define → process.env.
+// Falls back to empty string for OSS builds (no build-config.json).
+const _phKey          = process.env.DRAFT_PH_KEY           ?? "";
+const _phHost         = process.env.DRAFT_PH_HOST          ?? "https://us.i.posthog.com";
+const _crispWebsiteId = process.env.DRAFT_CRISP_WEBSITE_ID ?? "";
 
 // ── Application menu ───────────────────────────────────────────────────────────
 
@@ -1008,6 +1009,10 @@ const rpc = BrowserView.defineRPC<AppRPCType>({
         } catch {
           return { version: "dev", channel: "dev" };
         }
+      },
+
+      getCrispConfig: async () => {
+        return { website_id: _crispWebsiteId };
       },
 
       getAnalyticsConfig: async () => {

--- a/desktop/src/rpc/schema.ts
+++ b/desktop/src/rpc/schema.ts
@@ -528,8 +528,8 @@ export type AppRPCType = {
       /** Open Finder with the file selected (macOS `open -R`). */
       revealInFinder: { params: { relativePath: string }; response: ActionResult };
 
-      /** Return Crisp website ID baked in at build time. Empty string for OSS builds. */
-      getCrispConfig: { params: void; response: { website_id: string } };
+      /** Return support config baked in at build time. Empty strings for OSS builds. */
+      getCrispConfig: { params: void; response: { website_id: string; cal_url: string } };
 
       /** Read analytics config from ~/.draft/config.json. Generates anonymous_id on first call. */
       getAnalyticsConfig: { params: void; response: AnalyticsConfig };

--- a/desktop/src/rpc/schema.ts
+++ b/desktop/src/rpc/schema.ts
@@ -528,6 +528,9 @@ export type AppRPCType = {
       /** Open Finder with the file selected (macOS `open -R`). */
       revealInFinder: { params: { relativePath: string }; response: ActionResult };
 
+      /** Return Crisp website ID baked in at build time. Empty string for OSS builds. */
+      getCrispConfig: { params: void; response: { website_id: string } };
+
       /** Read analytics config from ~/.draft/config.json. Generates anonymous_id on first call. */
       getAnalyticsConfig: { params: void; response: AnalyticsConfig };
 


### PR DESCRIPTION
Adds a headless Crisp chat integration to the desktop app — no iframe widget, no floating bubble. The SDK initializes hidden and we wire up send/receive to a custom React panel.

- installs crisp-sdk-web; injects WEBSITE_ID at build time via electrobun.config.ts
- adds getCrispConfig RPC (main process → webview)
- useCrispChat hook: initializes Crisp hidden, manages message state, exposes sendMessage/onMessageReceived
- SupportPanel component: floating bottom-right chat panel with user/operator bubbles
- entry point moved to Settings ("Share Feedback" section, bottom of page)
- removed from sidebar footer where it was orphaned