### PR TITLE
fix(headless): detect auth failures via stdout, preflight check befor…

### DIFF
--- a/core/src/__tests__/headless.test.ts
+++ b/core/src/__tests__/headless.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, mock } from "bun:test";
+
+// Mock exec BEFORE importing headless — Bun evaluates mock.module synchronously
+// before the first import of the mocked path.
+let mockCaptureImpl: () => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+
+mock.module("../exec", () => ({
+  capture: (..._args: unknown[]) => mockCaptureImpl(),
+  spawn:   (..._args: unknown[]) => Promise.resolve(0),
+}));
+
+const { classifyOutput, isClaudeAuthenticated } = await import("../agents/headless");
+
+// ── real stdout fixtures pulled from context-bootstrap-*.log failures ──────────
+const NOT_LOGGED_IN = "Not logged in · Please run /login";
+const EXPIRED_TOKEN = "Failed to authenticate. API Error: 401 OAuth access token has expired. Re-authenticate to continue.";
+const INVALID_CREDS = "Failed to authenticate. API Error: 401 Invalid authentication credentials";
+
+describe("classifyOutput", () => {
+  it("classifies 'not logged in' stdout as an auth error, not the generic fallback", () => {
+    // Before the fix, this text lived in stdout and classifyStderr(stderr) only
+    // ever saw stderr — which was empty in all three real failures — so this
+    // always fell through to the generic "Something went wrong" message.
+    expect(classifyOutput(NOT_LOGGED_IN)).toBe(
+      "You're not signed in to Claude Code. Open a terminal, run `claude`, then `/login` to sign in — then retry context setup."
+    );
+  });
+
+  it("classifies an expired OAuth token 401 as an auth error", () => {
+    expect(classifyOutput(EXPIRED_TOKEN)).toContain("not signed in to Claude Code");
+  });
+
+  it("classifies invalid credentials 401 as an auth error", () => {
+    expect(classifyOutput(INVALID_CREDS)).toContain("not signed in to Claude Code");
+  });
+
+  it("still falls back to the generic message for unrecognized errors", () => {
+    expect(classifyOutput("some completely unrelated crash")).toBe(
+      "Something went wrong. You can retry or set up context manually."
+    );
+  });
+});
+
+describe("isClaudeAuthenticated", () => {
+  it("returns false when the keychain lookup fails (never logged in)", async () => {
+    mockCaptureImpl = async () => ({ exitCode: 1, stdout: "", stderr: "not found" });
+    expect(await isClaudeAuthenticated()).toBe(false);
+  });
+
+  it("returns true when the keychain entry exists", async () => {
+    mockCaptureImpl = async () => ({ exitCode: 0, stdout: "password", stderr: "" });
+    expect(await isClaudeAuthenticated()).toBe(true);
+  });
+});

--- a/core/src/agents/headless.ts
+++ b/core/src/agents/headless.ts
@@ -8,8 +8,12 @@
 
 import { join } from "path";
 import { existsSync, mkdirSync, writeFileSync, appendFileSync, unlinkSync, readdirSync } from "fs";
+import { homedir, platform } from "os";
 import { capture } from "../exec";
 import { DRAFT_ROOT } from "../config";
+
+const NOT_AUTHENTICATED_ERROR =
+  "You're not signed in to Claude Code. Open a terminal, run `claude`, then `/login` to sign in — then retry context setup.";
 
 const HEADLESS_LOG_DIR = join(DRAFT_ROOT, "logs", "headless");
 
@@ -57,6 +61,22 @@ export async function resolveRunnerBin(name: string): Promise<string | null> {
   return null;
 }
 
+/**
+ * Preflight only — checks whether Claude Code has *ever* logged in, not
+ * whether that session is still valid. macOS stores the OAuth token in
+ * Keychain; there's no local way to validate it without a network call, and
+ * `spawnHeadlessAgent`'s stdout classification already catches expired
+ * tokens on the real run. This exists to skip a doomed run entirely for the
+ * common "never logged in" case, not to guarantee auth is good.
+ */
+export async function isClaudeAuthenticated(): Promise<boolean> {
+  if (platform() === "darwin") {
+    const result = await capture(["security", "find-generic-password", "-s", "Claude Code-credentials"]);
+    return result.exitCode === 0;
+  }
+  return existsSync(join(homedir(), ".claude", ".credentials.json"));
+}
+
 export async function spawnHeadlessAgent(
   opts: SpawnHeadlessAgentOpts,
 ): Promise<SpawnHeadlessAgentResult> {
@@ -68,6 +88,14 @@ export async function spawnHeadlessAgent(
   const runnerBin = await resolveRunnerBin(runner);
   if (!runnerBin) {
     return { ok: false, error: `${runnerName} CLI not found. Install it first or run /draft-setup manually.` };
+  }
+
+  // TODO(backlog): automate this via a detached tmux session that drives
+  // `claude` → `/login`, scrapes the OAuth URL from the pane, opens it for
+  // the user, and polls for success — deferred, tmux-scraping a TUI is
+  // fragile and this manual path is the safe baseline (see decision 2026-07-21).
+  if (runner === "claude" && !(await isClaudeAuthenticated())) {
+    return { ok: false, error: NOT_AUTHENTICATED_ERROR };
   }
 
   const ts = Date.now();
@@ -139,7 +167,8 @@ export async function spawnHeadlessAgent(
       if (exitCode === 0) {
         notify({ phase: "complete", label: "Context setup complete." });
       } else {
-        notify({ phase: "error", label: classifyStderr(stderr), error: stderr || `Exited with code ${exitCode}.` });
+        const combinedOutput = `${stdout}\n${stderr}`;
+        notify({ phase: "error", label: classifyOutput(combinedOutput), error: stderr || stdout || `Exited with code ${exitCode}.` });
       }
     } finally {
       try { unlinkSync(promptPath); } catch {}
@@ -150,8 +179,15 @@ export async function spawnHeadlessAgent(
   return { ok: true };
 }
 
-function classifyStderr(stderr: string): string {
-  const s = stderr.toLowerCase();
+// Claude Code's `-p` CLI writes auth failures ("Not logged in · Please run
+// /login", "Failed to authenticate. API Error: 401 ...") to stdout, not
+// stderr — so this must check both. Confirmed from real failure logs where
+// stderr was empty and the error text was in stdout.
+export function classifyOutput(output: string): string {
+  const s = output.toLowerCase();
+  if (s.includes("not logged in") || s.includes("failed to authenticate") || s.includes("please run /login") || s.includes("401")) {
+    return NOT_AUTHENTICATED_ERROR;
+  }
   if (s.includes("auth") || s.includes("login")) return "Your session expired. Sign in and try again.";
   if (s.includes("rate") || s.includes("429")) return "Rate limited. Wait a moment and try again.";
   if (s.includes("token") || s.includes("context length") || s.includes("too long")) return "Too much content to process at once. Try with a smaller folder.";


### PR DESCRIPTION
…e spawn

Claude Code's `-p` CLI writes auth failures to stdout, not stderr, so classifyStderr() never matched them and users saw a generic "Something went wrong" message instead of a clear sign-in prompt. Confirmed from three real context-bootstrap logs where stderr was empty.

- classifyOutput() now checks combined stdout+stderr, with a specific message for "not logged in" / 401 / "failed to authenticate"
- isClaudeAuthenticated() preflight (Keychain on macOS, credentials file elsewhere) skips a doomed spawn entirely for the never-logged-in case; expired tokens still surface via classifyOutput on the real run