### PR TITLE
fix(daemon): stop draining multi-day session backlog on restart

### DIFF
--- a/background/draft-background.ts
+++ b/background/draft-background.ts
@@ -10,6 +10,7 @@ import { PostHog } from 'posthog-node';
 import { getActiveProfile, getWorkspacePath, BACKGROUND_DIR, readDraftConfig, readLocalConfig, ensureAnalyticsConfig } from 'draft-core/config';
 import { runMigrations } from 'draft-core/migrations/runner';
 import { reconcileSkillManifest, detectPending } from 'draft-core/scanner';
+import { isToday } from 'draft-core/time';
 import { withProfileSwitchLock } from 'draft-core/sync/team-assets';
 import { atomicPatch } from 'draft-core/sync/atomic-write';
 import { mkdirSync, existsSync, appendFileSync, openSync, readdirSync, readFileSync, unlinkSync, renameSync, writeFileSync } from 'fs';
@@ -23,8 +24,15 @@ const DRAFT_WORKSPACE = getWorkspacePath(ACTIVE_PROFILE);
 const DRAFT_PENDING    = `${DRAFT_BACKGROUND}/pending`;
 const DRAFT_PROCESSING = `${DRAFT_BACKGROUND}/processing`;
 const DRAFT_FAILED     = `${DRAFT_BACKGROUND}/failed`;
+const DRAFT_DEFERRED   = `${DRAFT_BACKGROUND}/deferred`;
 const DRAFT_LOGS       = `${DRAFT_BACKGROUND}/logs`;
 const STATE_DIR        = `${DRAFT_BACKGROUND}/state`;
+
+// Session-synthesis jobs (Claude Code + Codex) are expensive — each spawns a
+// real `claude -p` call. If the daemon was off for a few days, don't drain the
+// whole backlog on restart: only synthesize sessions from today, and move
+// older ones to deferred/ instead of processing or deleting them.
+const SESSION_JOB_SOURCES = new Set(['claude-code-session', 'codex-session']);
 
 // Per-profile local config — read once at startup
 const _localCfgResult = readLocalConfig(DRAFT_WORKSPACE);
@@ -45,6 +53,7 @@ const SKILL_SYNC_MS      = 5 * 60 * 1000;
 mkdirSync(DRAFT_PENDING,    { recursive: true });
 mkdirSync(DRAFT_PROCESSING, { recursive: true });
 mkdirSync(DRAFT_FAILED,     { recursive: true });
+mkdirSync(DRAFT_DEFERRED,   { recursive: true });
 mkdirSync(DRAFT_LOGS,       { recursive: true });
 mkdirSync(STATE_DIR,        { recursive: true });
 
@@ -230,6 +239,15 @@ async function processJob(jobPath: string) {
   if (jobSource === 'claude-code-session' && !CLAUDE_CODE_SYNTHESIS_ON) {
     log('info', `job ${jobName}: claude-code synthesis disabled — dropping`);
     try { unlinkSync(processingPath); } catch {}
+    return;
+  }
+
+  // Session-synthesis jobs are expensive (real LLM calls). If this job is from
+  // a prior day — e.g. the daemon was off and the backlog piled up — defer it
+  // instead of burning tokens processing the whole backlog on restart.
+  if (SESSION_JOB_SOURCES.has(jobSource) && !isToday(job.timestamp as string | undefined)) {
+    log('info', `job ${jobName}: not from today — deferring (source=${jobSource})`);
+    try { renameSync(processingPath, `${DRAFT_DEFERRED}/${jobName}`); } catch {}
     return;
   }
 

--- a/background/integrations/codex/codex-scanner.ts
+++ b/background/integrations/codex/codex-scanner.ts
@@ -172,7 +172,6 @@ export async function runCodexScan(options: ScannerOptions = {}): Promise<void> 
       : 360 * 60_000);
 
   const { state, legacyProcessedIds } = await loadState(statePath);
-  const isFirstScan = !state.last_scanned_at;
   pruneState(state, nowMs);
 
   mkdirSync(pendingDir, { recursive: true });
@@ -180,7 +179,10 @@ export async function runCodexScan(options: ScannerOptions = {}): Promise<void> 
   mkdirSync(failedDir, { recursive: true });
 
   const suppressedIds = new Set(state.suppressed_sessions.map(entry => entry.session_id));
-  const daysToScan = isFirstScan ? 1 : EXPIRY_DAYS;
+  // Only ever discover today's sessions. If the daemon was off for a few days,
+  // sessions from those days are intentionally left unscanned rather than all
+  // queued for synthesis at once when the daemon comes back up.
+  const daysToScan = 1;
   let observed = 0;
   let queued = 0;
   let retried = 0;

--- a/core/package.json
+++ b/core/package.json
@@ -25,6 +25,7 @@
     "./sync/team-assets":     "./src/sync/team-assets.ts",
     "./sync/publish":         "./src/sync/publish.ts",
     "./secrets":              "./src/secrets.ts",
+    "./time":                 "./src/time.ts",
     "./migrations/runner":    "./src/migrations/runner.ts"
   },
   "scripts": {

--- a/core/src/__tests__/time.test.ts
+++ b/core/src/__tests__/time.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { isSameLocalDay, isToday } from '../time';
+
+describe('isSameLocalDay', () => {
+  test('same calendar day, different times', () => {
+    expect(isSameLocalDay(new Date(2026, 5, 13, 1, 0), new Date(2026, 5, 13, 23, 0))).toBe(true);
+  });
+
+  test('different calendar days', () => {
+    expect(isSameLocalDay(new Date(2026, 5, 12, 23, 59), new Date(2026, 5, 13, 0, 1))).toBe(false);
+  });
+});
+
+describe('isToday', () => {
+  const now = new Date(2026, 5, 13, 12, 0);
+
+  test('timestamp from today', () => {
+    expect(isToday(new Date(2026, 5, 13, 8, 0).toISOString(), now)).toBe(true);
+  });
+
+  test('timestamp from a prior day (multi-day daemon backlog)', () => {
+    expect(isToday(new Date(2026, 5, 10, 8, 0).toISOString(), now)).toBe(false);
+  });
+
+  test('missing timestamp', () => {
+    expect(isToday(undefined, now)).toBe(false);
+  });
+
+  test('malformed timestamp', () => {
+    expect(isToday('not-a-date', now)).toBe(false);
+  });
+});

--- a/core/src/time.ts
+++ b/core/src/time.ts
@@ -1,0 +1,22 @@
+// core/src/time.ts — shared "is this from today" logic.
+//
+// Used to cap backlog processing after the daemon has been off for a while:
+// both the Codex session scanner and the pending-job drain need the same
+// notion of "today" so a multi-day gap doesn't get synthesized all at once.
+
+/** True if `a` and `b` fall on the same local calendar day. */
+export function isSameLocalDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear()
+    && a.getMonth() === b.getMonth()
+    && a.getDate() === b.getDate()
+  );
+}
+
+/** True if `iso` parses to a valid date that falls on the same local day as `now`. */
+export function isToday(iso: string | undefined, now: Date = new Date()): boolean {
+  if (!iso) return false;
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return isSameLocalDay(parsed, now);
+}


### PR DESCRIPTION
The Codex scanner rescanned 7 days back on every non-first scan, and the pending-job drain processed every file in pending/ with no cap. Combined, a daemon left off for a few days would synthesize the entire backlog of missed Claude Code and Codex sessions in one burst on restart, burning disproportionate tokens.

Codex scanning is now capped to today's date directory only. The pending drain now defers (not deletes) session-synthesis jobs whose timestamp isn't from today, via a shared isToday/isSameLocalDay helper in draft-core/time used by both call sites.